### PR TITLE
avoid using python v3.10 during build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -253,7 +253,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["ppc64le"] }}  # [ppc64le]
 
 build:
-  number: 8
+  number: 9
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH
@@ -276,7 +276,7 @@ build:
 requirements:
   build:
     - 7za  # [win]
-    - python >=3.7
+    - python <3.10
     # for run_exports
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
@@ -289,7 +289,7 @@ requirements:
 test:
   requires:
     - numba
-    - python >=3.7
+    - python <3.10
     - setuptools  # for pkg_resources
   commands:
     - test ! -f "${PREFIX}/lib/libaccinj64.so"         # [linux]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The build pulls `python v3.10` and fails with the following error:
```
conda.CondaMultiError: The package for python located at ../pkgs/python-3.10.0-h836d2c2_2
appears to be corrupted. The path 'lib/python3.1'
specified in the package manifest cannot be found.
```

This PR adds a change to avoid using `python v3.10`. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
