### PR TITLE
Fixed symlink breakage when the build is done using root user

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -253,7 +253,7 @@ source:
     md5: {{ cudavars[major_minor]["checksums"]["ppc64le"] }}  # [ppc64le]
 
 build:
-  number: 9
+  number: 10
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

When cudatoolkit is built using root user (either on baremetal or containers), the cuda run file extraction changes `/usr/local/cuda` symlink to point to the tmp directory where the runfile contents are extracted. And later, that tmp directory is deleted after copying its stuff to $PREFIX during conda-build process. This leaves `/usr/local/cuda` symlink  in a dangling state. And then the subsequent builds like nccl fail when it can't locate cuda headers in `/usr/local/cuda`.
Since root user has permissions to change `/usr/local` dir, this issue happens only with root user.

With non-root user, this scenario doesn't occur as the non-root user gets "Permission Denied" error while changing the symlink.

In order to fix this problem, we need to restore the `/usr/local/cuda` to whatever it was pointing to before runfile extraction.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
